### PR TITLE
UpdateHandler.php bug fix for supergroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.2.3 - 2025-08-26
+
+### What's Changed
+
+* FileStorage error control operator for delete by @JhnBer in https://github.com/westacks/telebot/pull/133
+
+**Full Changelog**: https://github.com/westacks/telebot/compare/4.2.2...4.2.3
+
 ## 4.2.2 - 2025-08-25
 
 ### What's Changed

--- a/src/Foundation/FileStorage.php
+++ b/src/Foundation/FileStorage.php
@@ -39,6 +39,6 @@ class FileStorage implements StorageContract
 
     public function delete(string $key): bool
     {
-        return unlink($this->path($key));
+        return @unlink($this->path($key));
     }
 }

--- a/src/Foundation/FileStorage.php
+++ b/src/Foundation/FileStorage.php
@@ -39,6 +39,6 @@ class FileStorage implements StorageContract
 
     public function delete(string $key): bool
     {
-        return unlink($this->path($key));
+        return file_exists($path = $this->path($key)) && unlink($path);
     }
 }

--- a/src/Foundation/FileStorage.php
+++ b/src/Foundation/FileStorage.php
@@ -39,6 +39,6 @@ class FileStorage implements StorageContract
 
     public function delete(string $key): bool
     {
-        return file_exists($path = $this->path($key)) && unlink($path);
+        return unlink($this->path($key));
     }
 }

--- a/src/Foundation/RequestInputHandler.php
+++ b/src/Foundation/RequestInputHandler.php
@@ -8,18 +8,7 @@ use WeStacks\TeleBot\TeleBot;
 
 abstract class RequestInputHandler extends UpdateHandler
 {
-    /**
-     * Use
-     * {@see RequestInputHandler::trigger()},
-     * {@see RequestInputHandler::request()},
-     * {@see RequestInputHandler::accept()}
-     * methods instead.
-     *
-     * @param TeleBot $bot
-     * @return StorageContract
-     * @internal
-     */
-    protected static function storage(TeleBot $bot): StorageContract
+    private static function storage(TeleBot $bot): StorageContract
     {
         $storage = $bot->config['storage'] ?? FileStorage::class;
 

--- a/src/Foundation/RequestInputHandler.php
+++ b/src/Foundation/RequestInputHandler.php
@@ -8,7 +8,18 @@ use WeStacks\TeleBot\TeleBot;
 
 abstract class RequestInputHandler extends UpdateHandler
 {
-    private static function storage(TeleBot $bot): StorageContract
+    /**
+     * Use
+     * {@see RequestInputHandler::trigger()},
+     * {@see RequestInputHandler::request()},
+     * {@see RequestInputHandler::accept()}
+     * methods instead.
+     *
+     * @param TeleBot $bot
+     * @return StorageContract
+     * @internal
+     */
+    protected static function storage(TeleBot $bot): StorageContract
     {
         $storage = $bot->config['storage'] ?? FileStorage::class;
 

--- a/src/Foundation/UpdateHandler.php
+++ b/src/Foundation/UpdateHandler.php
@@ -38,7 +38,7 @@ abstract class UpdateHandler
             'from_chat_id' => $this->update->chat()->id ?? null,
             'user_id' => $this->update->user()->id ?? null,
             'message_id' => $this->update->message()->message_id ?? null,
-            'message_thread_id' => $this->update->message()->message_thread_id ?? null,
+            'message_thread_id' => $this->update->chat()->is_forum ? ($this->update->message()->message_thread_id ?? null) : null,
             'business_connection_id' => $this->update->message()->business_connection_id ?? null,
             'sender_chat_id' => $this->update->message()->sender_chat->id ?? null,
             'callback_query_id' => $this->update->callback_query->id ?? null,


### PR DESCRIPTION
### Steps to reproduce
- Create supergroup without topics
- Create bot and add bot to this group
- Send message via bot to this group
- Reply to this message 
- Forward replied message to the private chat with user

If the bot's task is to forward a reply message to a private chat with the user, then the error "thread id not found" will occur.

```json
{
  "update_id": 857192578,
  "message": {
    "message_id": 112,
    "message_thread_id": 111,
    "from": {
      "id": 439044444,
      "is_bot": false,
      "first_name": "John",
      "last_name": "Ber",
      "username": "john_ber",
      "language_code": "en"
    },
    "date": 1756821534,
    "chat": {
      "id": -1002222000284,
      "type": "supergroup",
      "title": "Telebot v4 test",
      "username": "asfdzxvzx2312321zxccxz"
    },
    "reply_to_message": {
      "message_id": 111,
      "from": {
        "id": 7490005555,
        "is_bot": true,
        "first_name": "debug bot",
        "username": "debug_log_bot"
      },
      "date": 1756821528,
      "chat": {
        "id": -1002222211114,
        "type": "supergroup",
        "title": "Telebot v4 test",
        "username": "asfdzxvzx2312321zxccxz"
      },
      "text": "\u0417\u0430\u044f\u0432\u043a\u0430 #IT001519 \u043e\u0442 Ivan Berezhnoi\n\u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0435 \u043e\u0442 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f",
      "entities": [
        {
          "type": "hashtag",
          "offset": 7,
          "length": 9
        },
        {
          "type": "text_link",
          "offset": 20,
          "length": 14,
          "url": "https:\/\/t.me\/john_ber"
        }
      ],
      "link_preview_options": {
        "is_disabled": true
      },
      "reply_markup": {
        "inline_keyboard": [
          [
            {
              "text": "\u0417\u0430\u043a\u0440\u044b\u0442\u044c #IT001519",
              "callback_data": "close:1527"
            }
          ]
        ]
      }
    },
    "text": "\u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0435 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044e"
  }
}
```

Telegram creates a virtual thread for a series of replies for a message.
In this case, we pass ```"message_thread_id": 111``` to the $merge array in the __call function. 


We can pass thread_id manually like this and it will fix error about wrong thread id
```php
$this->sendMessage([
    'text' => $tgText->join("\n"),
    [
        'chat_id' => 12312312,
        'message_thread_id' => null,
    ],
]);
```

But it looks like a cleaner option is to not pass the thread_id unless the supergroup is a forum.
