### PR TITLE
Fix UpdateHandler null exception when chat() is null

### DIFF
--- a/src/Foundation/UpdateHandler.php
+++ b/src/Foundation/UpdateHandler.php
@@ -38,7 +38,7 @@ abstract class UpdateHandler
             'from_chat_id' => $this->update->chat()->id ?? null,
             'user_id' => $this->update->user()->id ?? null,
             'message_id' => $this->update->message()->message_id ?? null,
-            'message_thread_id' => $this->update->chat()->is_forum ? ($this->update->message()->message_thread_id ?? null) : null,
+            'message_thread_id' => $this->update->chat()?->is_forum ? ($this->update->message()->message_thread_id ?? null) : null,
             'business_connection_id' => $this->update->message()->business_connection_id ?? null,
             'sender_chat_id' => $this->update->message()->sender_chat->id ?? null,
             'callback_query_id' => $this->update->callback_query->id ?? null,


### PR DESCRIPTION
For `pre_checkout_query` and `successful_payment` updates, `UpdateHandler` throws a null reference exception when accessing `is_forum`:

`Attempt to read property "is_forum" on null ... UpdateHandler.php:41`

This happens because `chat()` returns `?Chat`, and for these update types it may be `null`.